### PR TITLE
FileNotFoundError when calling get_data() in case sensitive file systems (Linux)

### DIFF
--- a/util/read_data.py
+++ b/util/read_data.py
@@ -211,7 +211,7 @@ def get_t5():
         elif "xl" in name:
             return 2849804288
 
-    df = pd.read_csv("aggregated_eval/T5_pile.csv")
+    df = pd.read_csv("aggregated_eval/t5_pile.csv")
     df["checkpoint"] = df.apply(
         lambda row: hf_checkpoint(f"EleutherAI/pile-t5-{row['model_name']}", f"step_{row['steps']}"), axis=1)
     df["loss_cols"] = [["val_perplexity"]] * \
@@ -538,7 +538,7 @@ def get_llm360():
     test_df(df, DATA_AWARE_DF_COLS + ARCH_AWARE_DF_COLS)
     dfs.append(df)
 
-    df = pd.read_csv("aggregated_eval/k2.csv", index_col="index")
+    df = pd.read_csv("aggregated_eval/K2.csv", index_col="index")
     min_max_cols = [col for col in df.columns if col.endswith(
         "_MIN") or col.endswith("_MAX")]
     spike_cols = [col for col in df.columns if


### PR DESCRIPTION
fix: case-sensitivity issue in file paths of aggregated_eval data files K2 and t5

- What's broken: get_data() raises FileNotFoundError on case-sensitive filesystems (Linux) because the code references T5_pile.csv/k2.csv while the actual files in aggregated_eval/ are t5_pile.csv/K2.csv.

- Why it wasn't caught: likely invisible in development on macOS (APFS is case-insensitive by default), so it only surfaces for contributors on Linux.

- Scope: purely a filename-casing fix, no behavior change.